### PR TITLE
qwen4exp: --ngram-on-disk, the n-gram table read from the GGUF per batch

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2742,6 +2742,37 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_OVERRIDE_TENSOR"));
     add_opt(common_arg(
+        {"--ngram-on-disk"},
+        "keep the model's n-gram hash-embedding table (per_layer_token_embd, 28.8 GB on Qwen3.8-Flash-Next)\n"
+        "on disk: it is never mapped or loaded, each batch reads just the rows it gathers from the GGUF.\n"
+        "Only qwen4exp has such a table; on any other model this is a no-op",
+        [](common_params & params) {
+            params.ple_on_disk = true;
+        }
+    ).set_env("LLAMA_ARG_NGRAM_ON_DISK"));
+    add_opt(common_arg(
+        {"--ngram-io-threads"}, "N",
+        string_format("threads reading n-gram rows for --ngram-on-disk (default: %d)", params.ple_io_threads),
+        [](common_params & params, int value) {
+            params.ple_io_threads = value;
+        }
+    ).set_env("LLAMA_ARG_NGRAM_IO_THREADS"));
+    add_opt(common_arg(
+        {"--ngram-cache"}, "MiB",
+        string_format("in-memory cache of recently read n-gram rows for --ngram-on-disk, 0 disables (default: %d)", params.ple_cache_mb),
+        [](common_params & params, int value) {
+            params.ple_cache_mb = value;
+        }
+    ).set_env("LLAMA_ARG_NGRAM_CACHE"));
+    add_opt(common_arg(
+        {"--ngram-direct-io"},
+        {"--no-ngram-direct-io"},
+        string_format("read n-gram rows with O_DIRECT so they bypass the page cache (default: %s)", params.ple_direct_io ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.ple_direct_io = value;
+        }
+    ).set_env("LLAMA_ARG_NGRAM_DIRECT_IO"));
+    add_opt(common_arg(
         {"-cmoe", "--cpu-moe"},
         "keep all Mixture of Experts (MoE) weights in the CPU",
         [](common_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1692,6 +1692,10 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.check_tensors   = params.check_tensors;
     mparams.use_extra_bufts = !params.no_extra_bufts;
     mparams.no_host         = params.no_host;
+    mparams.ple_on_disk     = params.ple_on_disk;
+    mparams.ple_direct_io   = params.ple_direct_io;
+    mparams.ple_io_threads  = params.ple_io_threads;
+    mparams.ple_cache_mb    = params.ple_cache_mb;
 
     if (params.kv_overrides.empty()) {
         mparams.kv_overrides = NULL;

--- a/common/common.h
+++ b/common/common.h
@@ -574,6 +574,10 @@ struct common_params {
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
     bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
+    bool    ple_on_disk    = false; // keep the n-gram hash-embedding table on disk (qwen4exp)
+    bool    ple_direct_io  = true;  // ... read with O_DIRECT
+    int32_t ple_io_threads = 64;    // ... parallel readers (random 4 KiB reads: this NVMe gives 62k IOPS at 16, 130k at 64, ~160k at 128+)
+    int32_t ple_cache_mb   = 256;   // ... row cache, 0 disables
 
     bool single_turn       = false; // single turn chat conversation
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -336,6 +336,10 @@ extern "C" {
         // the GPU that is used for the entire model when split_mode is LLAMA_SPLIT_MODE_NONE
         int32_t main_gpu;
 
+        // n-gram hash-embedding table kept on disk (see ple_on_disk below)
+        int32_t ple_io_threads; // parallel pread workers
+        int32_t ple_cache_mb;   // in-memory cache of recently read rows, 0 disables
+
         // proportion of the model (layers or rows) to offload to each GPU, size: llama_max_devices()
         const float * tensor_split;
 
@@ -357,6 +361,9 @@ extern "C" {
         bool no_host;         // bypass host buffer allowing extra buffers to be used
         bool no_alloc;        // only load metadata and simulate memory allocations
         bool load_mtp;        // whether to load MTP layers
+        bool ple_on_disk;     // keep the n-gram hash-embedding table (per_layer_token_embd) on disk: never
+                              // mapped or loaded, the rows a batch needs are read from the file (qwen4exp)
+        bool ple_direct_io;   // read those rows with O_DIRECT, bypassing the page cache
     };
 
     struct llama_sampler_seq_config {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(llama
             llama-memory-hybrid-iswa.cpp
             llama-memory-recurrent.cpp
             llama-mmap.cpp
+            llama-ple-disk.cpp
             llama-model-loader.cpp
             llama-model-saver.cpp
             llama-model.cpp

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -593,6 +593,7 @@ llama_model_loader::llama_model_loader(
         llm_kv = LLM_KV(llm_arch_from_string(arch_name));
 
         files.emplace_back(new llama_file(fname.c_str(), "rb", use_direct_io));
+        fnames.push_back(fname);
         contexts.emplace_back(ctx);
 
         // Save tensors data offset of the main file.
@@ -661,6 +662,7 @@ llama_model_loader::llama_model_loader(
                 }
 
                 files.emplace_back(new llama_file(fname_split, "rb", use_direct_io));
+                fnames.push_back(fname_split);
                 contexts.emplace_back(ctx);
 
                 // Save tensors data offset info of the shard.
@@ -705,6 +707,7 @@ llama_model_loader::llama_model_loader(
         llm_kv = LLM_KV(llm_arch_from_string(arch_name));
 
         files.emplace_back(new llama_file(file));
+        fnames.push_back("(file*)");
         contexts.emplace_back(ctx);
 
         // Save tensors data offset info of the main file.

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -83,6 +83,7 @@ struct llama_model_loader {
     bool load_mtp;
 
     llama_files files;
+    std::vector<std::string> fnames; // one per entry of files, for readers that outlive the loader
     llama_ftype ftype;
     llama_fver  fver;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1663,7 +1663,9 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         }
     }
 
-    ml.init_mappings(true, use_mlock ? &pimpl->mlock_mmaps : nullptr);
+    // With the n-gram table left on disk, a populated mapping would pull the table's
+    // third of the file resident for nothing; readahead alone carries the sequential load.
+    ml.init_mappings(!params.ple_on_disk, use_mlock ? &pimpl->mlock_mmaps : nullptr);
     pimpl->mappings.reserve(ml.mappings.size());
 
     // create the backend buffers
@@ -2648,6 +2650,8 @@ llama_model_params llama_model_default_params() {
         /*.split_mode                  =*/ LLAMA_SPLIT_MODE_LAYER,
         /*.load_mode                   =*/ LLAMA_LOAD_MODE_AUTO,
         /*.main_gpu                    =*/ 0,
+        /*.ple_io_threads              =*/ 64,
+        /*.ple_cache_mb                =*/ 256,
         /*.tensor_split                =*/ nullptr,
         /*.progress_callback           =*/ nullptr,
         /*.progress_callback_user_data =*/ nullptr,
@@ -2658,6 +2662,8 @@ llama_model_params llama_model_default_params() {
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
         /*.load_mtp                    =*/ false,
+        /*.ple_on_disk                 =*/ false,
+        /*.ple_direct_io               =*/ true,
     };
 
     return result;

--- a/src/llama-ple-disk.cpp
+++ b/src/llama-ple-disk.cpp
@@ -1,0 +1,320 @@
+#include "llama-ple-disk.h"
+
+#include "llama-impl.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <cerrno>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+struct llama_ple_disk::impl {
+    std::string fname;
+    int         fd     = -1;
+    bool        direct = false;
+    size_t      offs   = 0;
+    ggml_type   type   = GGML_TYPE_COUNT;
+    int64_t     ne0    = 0;
+    int64_t     nrows  = 0;
+    size_t      rs     = 0;     // bytes per row
+    size_t      block  = 4096;  // O_DIRECT alignment for offset, length and buffer
+    ggml_to_float_t to_float = nullptr;
+
+    // direct-mapped cache of raw rows: slot = row & mask, tag = row
+    size_t               n_slots = 0;
+    size_t               mask    = 0;
+    std::vector<int64_t> tags;
+    std::vector<uint8_t> slab;
+
+    // per-gather scratch, reused
+    std::vector<int32_t>                       uniq;
+    std::vector<uint8_t>                       raw;      // [uniq.size(), rs]
+    std::vector<std::pair<int32_t, uint32_t>>  misses;   // (row, index into uniq)
+    uint8_t *                                  bounce0 = nullptr; // main-thread bounce buffer
+
+    std::mutex mtx; // one gather at a time; a model is shared by every context built on it
+
+    // reader pool, started on first use
+    int32_t                  n_threads = 1;
+    std::vector<std::thread> workers;
+    std::mutex               pm;
+    std::condition_variable  cv_work;
+    std::condition_variable  cv_done;
+    uint64_t                 gen     = 0;
+    size_t                   pending = 0;
+    std::atomic<size_t>      next{0};
+    bool                     stop    = false;
+
+    uint64_t st_calls = 0, st_rows = 0, st_uniq = 0, st_hits = 0, st_reads = 0, st_bytes = 0;
+    double   st_ms = 0;
+
+    impl(const std::string & fname, size_t offs, ggml_type type, int64_t ne0, int64_t nrows, const params & p)
+        : fname(fname), offs(offs), type(type), ne0(ne0), nrows(nrows) {
+#if defined(_WIN32)
+        throw std::runtime_error("llama_ple_disk: not supported on Windows");
+#else
+        if (ggml_is_quantized(type) && ne0 % ggml_blck_size(type) != 0) {
+            throw std::runtime_error(format("llama_ple_disk: row of %lld %s elements is not a whole number of blocks",
+                                            (long long) ne0, ggml_type_name(type)));
+        }
+        rs = ggml_row_size(type, ne0);
+        if (type != GGML_TYPE_F32) {
+            to_float = ggml_get_type_traits(type)->to_float;
+            if (to_float == nullptr) {
+                throw std::runtime_error(format("llama_ple_disk: no dequantizer for %s", ggml_type_name(type)));
+            }
+        }
+
+        direct = p.direct_io;
+        if (direct) {
+            fd = open(fname.c_str(), O_RDONLY | O_DIRECT | O_CLOEXEC);
+            if (fd < 0) {
+                LLAMA_LOG_WARN("%s: O_DIRECT open of %s failed (%s); falling back to buffered reads\n",
+                               __func__, fname.c_str(), strerror(errno));
+                direct = false;
+            }
+        }
+        if (fd < 0) {
+            fd = open(fname.c_str(), O_RDONLY | O_CLOEXEC);
+            if (fd < 0) {
+                throw std::runtime_error(format("llama_ple_disk: failed to open %s: %s", fname.c_str(), strerror(errno)));
+            }
+        }
+
+        n_threads = std::max<int32_t>(1, p.n_threads);
+
+        if (p.cache_bytes >= rs) {
+            size_t n = p.cache_bytes / rs;
+            n_slots = 1;
+            while (n_slots * 2 <= n) {
+                n_slots *= 2;
+            }
+            mask = n_slots - 1;
+            tags.assign(n_slots, -1);
+            slab.resize(n_slots * rs);
+        }
+#endif
+    }
+
+    ~impl() {
+#if !defined(_WIN32)
+        {
+            std::lock_guard<std::mutex> lk(pm);
+            stop = true;
+        }
+        cv_work.notify_all();
+        for (auto & w : workers) {
+            w.join();
+        }
+        free(bounce0);
+        if (fd >= 0) {
+            close(fd);
+        }
+#endif
+    }
+
+#if !defined(_WIN32)
+    size_t bounce_size() const {
+        return ((rs + block - 1) / block) * block + 2 * block;
+    }
+
+    uint8_t * alloc_bounce() const {
+        void * ptr = nullptr;
+        if (posix_memalign(&ptr, block, bounce_size()) != 0) {
+            throw std::runtime_error("llama_ple_disk: posix_memalign failed");
+        }
+        return (uint8_t *) ptr;
+    }
+
+    // read `len` bytes at `off` into `dst`; a short read is only tolerated past `need`
+    void pread_full(uint8_t * dst, size_t len, off_t off, size_t need) const {
+        size_t got = 0;
+        while (got < len) {
+            const ssize_t r = pread(fd, dst + got, len - got, off + (off_t) got);
+            if (r < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                GGML_ABORT("llama_ple_disk: pread(%s, %zu @ %lld) failed: %s",
+                           fname.c_str(), len, (long long) off, strerror(errno));
+            }
+            if (r == 0) {
+                break; // EOF
+            }
+            got += (size_t) r;
+        }
+        if (got < need) {
+            GGML_ABORT("llama_ple_disk: short read in %s: %zu of %zu bytes at %lld",
+                       fname.c_str(), got, need, (long long) off);
+        }
+    }
+
+    void read_row(int64_t row, uint8_t * dst, uint8_t * bounce) const {
+        const off_t off = (off_t) offs + (off_t) row * (off_t) rs;
+        if (!direct) {
+            pread_full(dst, rs, off, rs);
+            return;
+        }
+        const off_t  a0   = off & ~(off_t) (block - 1);
+        const size_t need = (size_t) (off - a0) + rs;
+        const size_t len  = ((need + block - 1) / block) * block;
+        pread_full(bounce, len, a0, need);
+        memcpy(dst, bounce + (off - a0), rs);
+    }
+
+    void worker() {
+        uint8_t * bounce = direct ? alloc_bounce() : nullptr;
+        uint64_t  seen   = 0;
+        for (;;) {
+            {
+                std::unique_lock<std::mutex> lk(pm);
+                cv_work.wait(lk, [&] { return stop || gen != seen; });
+                if (stop) {
+                    break;
+                }
+                seen = gen;
+            }
+            for (;;) {
+                const size_t i = next.fetch_add(1);
+                if (i >= misses.size()) {
+                    break;
+                }
+                read_row(misses[i].first, raw.data() + (size_t) misses[i].second * rs, bounce);
+            }
+            {
+                std::lock_guard<std::mutex> lk(pm);
+                if (--pending == 0) {
+                    cv_done.notify_one();
+                }
+            }
+        }
+        free(bounce);
+    }
+
+    void run_misses() {
+        if (n_threads <= 1 || misses.size() <= 2) {
+            if (direct && bounce0 == nullptr) {
+                bounce0 = alloc_bounce();
+            }
+            for (const auto & m : misses) {
+                read_row(m.first, raw.data() + (size_t) m.second * rs, bounce0);
+            }
+            return;
+        }
+        if (workers.empty()) {
+            workers.reserve(n_threads);
+            for (int32_t i = 0; i < n_threads; ++i) {
+                workers.emplace_back([this] { worker(); });
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lk(pm);
+            next    = 0;
+            pending = workers.size();
+            ++gen;
+        }
+        cv_work.notify_all();
+        std::unique_lock<std::mutex> lk(pm);
+        cv_done.wait(lk, [&] { return pending == 0; });
+    }
+
+    void gather(const int32_t * idx, size_t n, float * dst) {
+        std::lock_guard<std::mutex> lk(mtx);
+        const auto t0 = std::chrono::steady_clock::now();
+
+        uniq.assign(idx, idx + n);
+        std::sort(uniq.begin(), uniq.end());
+        uniq.erase(std::unique(uniq.begin(), uniq.end()), uniq.end());
+        if (!uniq.empty() && (uniq.front() < 0 || (int64_t) uniq.back() >= nrows)) {
+            GGML_ABORT("llama_ple_disk: row index out of range (%d..%d of %lld rows)",
+                       uniq.front(), uniq.back(), (long long) nrows);
+        }
+
+        raw.resize(uniq.size() * rs);
+        misses.clear();
+        for (size_t i = 0; i < uniq.size(); ++i) {
+            if (n_slots) {
+                const size_t slot = (size_t) uniq[i] & mask;
+                if (tags[slot] == uniq[i]) {
+                    memcpy(raw.data() + i * rs, slab.data() + slot * rs, rs);
+                    continue;
+                }
+            }
+            misses.emplace_back(uniq[i], (uint32_t) i);
+        }
+
+        if (!misses.empty()) {
+            run_misses();
+            if (n_slots) {
+                for (const auto & m : misses) {
+                    const size_t slot = (size_t) m.first & mask;
+                    tags[slot] = m.first;
+                    memcpy(slab.data() + slot * rs, raw.data() + (size_t) m.second * rs, rs);
+                }
+            }
+        }
+
+        for (size_t k = 0; k < n; ++k) {
+            const size_t    i   = (size_t) (std::lower_bound(uniq.begin(), uniq.end(), idx[k]) - uniq.begin());
+            const uint8_t * src = raw.data() + i * rs;
+            float *         out = dst + k * (size_t) ne0;
+            if (to_float) {
+                to_float(src, out, ne0);
+            } else {
+                memcpy(out, src, rs);
+            }
+        }
+
+        st_calls += 1;
+        st_rows  += n;
+        st_uniq  += uniq.size();
+        st_hits  += uniq.size() - misses.size();
+        st_reads += misses.size();
+        st_bytes += misses.size() * (direct ? block : rs);
+        st_ms    += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    }
+#endif
+};
+
+llama_ple_disk::llama_ple_disk(const std::string & fname, size_t offs, ggml_type type, int64_t ne0, int64_t nrows, const params & p)
+    : pimpl(std::make_unique<impl>(fname, offs, type, ne0, nrows, p)) {}
+
+llama_ple_disk::~llama_ple_disk() {
+    if (pimpl->st_calls) {
+        LLAMA_LOG_INFO("%s: %llu batches, %llu rows gathered (%llu unique): %llu cache hits, %llu disk reads (%.1f MiB), %.1f ms total\n",
+                       __func__, (unsigned long long) pimpl->st_calls, (unsigned long long) pimpl->st_rows,
+                       (unsigned long long) pimpl->st_uniq, (unsigned long long) pimpl->st_hits,
+                       (unsigned long long) pimpl->st_reads, pimpl->st_bytes / (1024.0 * 1024.0), pimpl->st_ms);
+    }
+}
+
+void llama_ple_disk::gather(const int32_t * idx, size_t n, float * dst) {
+#if defined(_WIN32)
+    GGML_UNUSED(idx); GGML_UNUSED(n); GGML_UNUSED(dst);
+    GGML_ABORT("llama_ple_disk: not supported on Windows");
+#else
+    pimpl->gather(idx, n, dst);
+#endif
+}
+
+int64_t llama_ple_disk::n_rows()   const { return pimpl->nrows; }
+int64_t llama_ple_disk::ne0()      const { return pimpl->ne0;   }
+size_t  llama_ple_disk::row_size() const { return pimpl->rs;    }
+
+std::string llama_ple_disk::describe() const {
+    return format("%s @ %zu: %lld rows x %lld %s (%zu B/row, %.2f GiB), %s I/O, %d threads, row cache %zu MiB",
+                  pimpl->fname.c_str(), pimpl->offs, (long long) pimpl->nrows, (long long) pimpl->ne0,
+                  ggml_type_name(pimpl->type), pimpl->rs, (double) pimpl->nrows * pimpl->rs / (1024.0 * 1024.0 * 1024.0),
+                  pimpl->direct ? "direct" : "buffered", pimpl->n_threads,
+                  pimpl->n_slots * pimpl->rs / (1024 * 1024));
+}

--- a/src/llama-ple-disk.h
+++ b/src/llama-ple-disk.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "ggml.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+// A weight table that stays in the GGUF file. Nothing is mapped or loaded for it at
+// model load; each batch reads exactly the rows it gathers, with pread, and hands
+// them over dequantized.
+//
+// Built for the qwen4exp n-gram hash embedding (per_layer_token_embd): 320 M rows of
+// 90 bytes, a third of the model's bytes, of which one token touches 16 at unrelated
+// hashed offsets. The working set is a few thousand rows per batch, so the table has
+// no business being resident -- on a unified-memory machine it competes with the
+// weights and the KV cache for the same RAM.
+struct llama_ple_disk {
+    struct params {
+        int32_t n_threads   = 64;         // parallel readers: random reads on NVMe need queue depth
+        size_t  cache_bytes = 256u << 20; // direct-mapped cache of raw rows; 0 disables
+        bool    direct_io   = true;       // O_DIRECT, so the rows never enter the page cache either
+    };
+
+    llama_ple_disk(const std::string & fname, size_t offs, ggml_type type, int64_t ne0, int64_t nrows, const params & p);
+    ~llama_ple_disk();
+
+    // dequantize rows idx[0..n) into dst, laid out [ne0, n]; aborts on an out-of-range index
+    void gather(const int32_t * idx, size_t n, float * dst);
+
+    int64_t     n_rows()   const;
+    int64_t     ne0()      const;
+    size_t      row_size() const;
+    std::string describe() const;
+
+    struct impl;
+    std::unique_ptr<impl> pimpl;
+};

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -2276,6 +2276,8 @@ struct llama_model_qwen35 : public llama_model_base {
 };
 
 
+struct llama_ple_disk;
+
 struct llama_model_qwen4exp : public llama_model_base {
     llama_model_qwen4exp(const struct llama_model_params & params) : llama_model_base(params) {}
 
@@ -2298,6 +2300,9 @@ struct llama_model_qwen4exp : public llama_model_base {
     // A file written the upstream way carries the heads joined into one tensor instead.
     // It is read through 16 views, so the graph does not care which layout it got.
     ggml_tensor * ple_joined = nullptr;
+    // set when the joined table is left on disk (params.ple_on_disk): ple_joined stays null
+    // and build_ple takes its rows from this reader instead of ggml_get_rows
+    std::shared_ptr<llama_ple_disk> ple_disk;
     void load_arch_hparams(llama_model_loader & ml) override;
     void load_arch_tensors(llama_model_loader & ml) override;
 

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -1,6 +1,7 @@
 #include "models.h"
 #include "llama-memory-hybrid.h"
 #include "llama-memory-recurrent.h"
+#include "llama-ple-disk.h"
 
 void llama_model_qwen4exp::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,        hparams.n_ff_exp, false);
@@ -103,10 +104,24 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
     if (hparams.ple_n_heads > 0) {
         const std::string joined = tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight").str();
         if (const auto * w = ml.get_weight(joined.c_str())) {
-            // Upstream layout: every head in one tensor. It stays on the host whatever
-            // -ngl says, because it is past the buffer size a device will accept.
-            ple_joined = create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
-                                       { hparams.ple_head_dim, w->tensor->ne[1] }, 0);
+            if (params.ple_on_disk) {
+                // The table is counted as created but never allocated, mapped or read; each
+                // ubatch gathers its rows straight from the file (llm_graph_input_ple::set_input).
+                llama_ple_disk::params dp;
+                dp.n_threads   = params.ple_io_threads;
+                dp.cache_bytes = params.ple_cache_mb > 0 ? (size_t) params.ple_cache_mb << 20 : 0;
+                dp.direct_io   = params.ple_direct_io;
+                ple_disk = std::make_shared<llama_ple_disk>(ml.fnames.at(w->idx), w->offs,
+                                                            w->tensor->type, w->tensor->ne[0], w->tensor->ne[1], dp);
+                LLAMA_LOG_INFO("%s: PLE n-gram table stays on disk: %s\n", __func__, ple_disk->describe().c_str());
+                create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
+                              { hparams.ple_head_dim, w->tensor->ne[1] }, TENSOR_SKIP);
+            } else {
+                // Upstream layout: every head in one tensor. It stays on the host whatever
+                // -ngl says, because it is past the buffer size a device will accept.
+                ple_joined = create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
+                                           { hparams.ple_head_dim, w->tensor->ne[1] }, 0);
+            }
         } else {
             ple_ngram_embd.resize(hparams.ple_n_heads);
             for (uint32_t h = 0; h < hparams.ple_n_heads; ++h) {
@@ -999,6 +1014,10 @@ public:
     void set_input(const llama_ubatch * ubatch) override;
 
     ggml_tensor * rows = nullptr;   // I32 [ple_n_heads * n_tokens]
+    ggml_tensor * embd = nullptr;   // F32 [ple_head_dim, ple_n_heads * n_tokens]: the gathered rows, when the table is on disk
+
+    std::vector<float>   embd_buf;
+    std::vector<int32_t> rows_global;
 
     const llama_model_qwen4exp & pmodel;
 };
@@ -1110,6 +1129,22 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
         h.next_pos = pos + 1;
     }
 
+    if (pmodel.ple_disk) {
+        // idx is head-major and head-local; the reader wants one global row per (token, head)
+        // in token-major order, which is the layout the per-head gather + concat produces.
+        GGML_ASSERT(embd != nullptr && rows == nullptr);
+        rows_global.resize(idx.size());
+        for (int64_t i = 0; i < n_tokens; ++i) {
+            for (int64_t h = 0; h < n_heads; ++h) {
+                rows_global[i*n_heads + h] = (int32_t) (idx[h*n_tokens + i] + (int64_t) hp.ple_head_offsets[h]);
+            }
+        }
+        embd_buf.resize(rows_global.size() * (size_t) hp.ple_head_dim);
+        pmodel.ple_disk->gather(rows_global.data(), rows_global.size(), embd_buf.data());
+        ggml_backend_tensor_set(embd, embd_buf.data(), 0, embd_buf.size() * sizeof(float));
+        return;
+    }
+
     ggml_backend_tensor_set(rows, idx.data(), 0, idx.size()*ggml_element_size(rows));
 }
 
@@ -1184,9 +1219,20 @@ ggml_tensor * llama_model_qwen4exp::graph::build_ple(
     auto ple_inp = std::make_unique<llm_graph_input_ple>(
             static_cast<const llama_model_qwen4exp &>(model));
 
-    ple_inp->rows = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_heads * n_tokens);
-    ggml_set_input(ple_inp->rows);
-    ggml_tensor * rows = ple_inp->rows;
+    const auto & qmodel = static_cast<const llama_model_qwen4exp &>(model);
+    ggml_tensor * rows = nullptr;
+    ggml_tensor * emb  = nullptr;
+    if (qmodel.ple_disk) {
+        // table on disk: the gather happened in set_input and arrives as an F32 input,
+        // token-major, which reshapes to what the per-head gathers + concat produce
+        ple_inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.ple_head_dim, n_heads * n_tokens);
+        ggml_set_input(ple_inp->embd);
+        emb = ple_inp->embd;
+    } else {
+        ple_inp->rows = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_heads * n_tokens);
+        ggml_set_input(ple_inp->rows);
+        rows = ple_inp->rows;
+    }
     res->add_input(std::move(ple_inp));
 
     // gather then flatten the heads: get_rows already lays the head dimension
@@ -1194,10 +1240,7 @@ ggml_tensor * llama_model_qwen4exp::graph::build_ple(
     // One gather per head, then concatenate along the row axis. Concatenating in head
     // order reproduces exactly what the single gather over the joined table produced,
     // because that laid the head dimension out slowest.
-    const auto & qmodel = static_cast<const llama_model_qwen4exp &>(model);
-
-    ggml_tensor * emb = nullptr;
-    for (int64_t h = 0; h < n_heads; ++h) {
+    for (int64_t h = 0; rows != nullptr && h < n_heads; ++h) {
         ggml_tensor * tbl = qmodel.ple_joined
             ? ggml_view_2d(ctx0, qmodel.ple_joined, hparams.ple_head_dim, hparams.ple_head_vocab_sizes[h],
                            qmodel.ple_joined->nb[1], hparams.ple_head_offsets[h]*qmodel.ple_joined->nb[1])


### PR DESCRIPTION
The 28.8 GB `per_layer_token_embd` never fits a unified-memory machine, and on this backend even `-ot per_layer_token_embd=CPU` lands it in the GPU heap (host-visible memory is GTT): measured 113 GB and swapping on a 128 GB Strix Halo. The per-head split keeps it resident but only fits with IQ4_XS.

This adds `--ngram-on-disk`: the loader counts the tensor as created and never allocates, maps or reads it; each ubatch computes its hash indices as before and hands them to a small reader (`src/llama-ple-disk.{h,cpp}`) that `pread`s exactly those rows from the GGUF — `O_DIRECT` so they do not enter the page cache either, a thread pool (random 4 KiB reads need queue depth: this NVMe gives 62k IOPS at 16 threads, 130k at 64), a direct-mapped cache of raw rows — dequantizes them with the type's `to_float` and feeds an F32 input in place of the per-head gathers. This tree indexes the table head-major and head-local, so the gather reorders to token-major global rows. `--ngram-io-threads` (64), `--ngram-cache` (MiB, 256), `--ngram-direct-io` (default on, falls back to buffered).

Measured on Strix Halo (RADV, Mesa 26.1), UD-IQ4_XS:
- decode identical to the per-head split (bit-exact rows: the reader is checked against a dequantized mmap of the same rows, 280k rows incl. duplicates and cache collisions, 0 mismatches; the `ple_embd` tensors hash identical to the in-memory path)
- gather cost ~250 ms per 2048-token prefill ubatch (32,768 random rows), ~0.5 ms per decode token
- process RSS 0.5 GB; 262K context with two slots in 83.5 GB of GTT; load 40 s
- with the joined UD-Q4_K_XL, which does not fit any other way here: 20.8 t/s bare

Also carried on the ROCm/CUDA backend of the same tree without changes (it is backend-agnostic: the rows arrive as a graph input).
