### PR TITLE
convert: an --mtp export of qwen4exp must not need the PLE constants

### DIFF
--- a/conversion/qwen4exp.py
+++ b/conversion/qwen4exp.py
@@ -103,8 +103,10 @@ class Qwen4ExpTextModel(_Qwen35MRopeMixin, _LinearAttentionVReorderBase):
         self.gguf_writer.add_attention_compress_ratios(ratios)
 
         # ple_layer_ids is 1-based in the HF config; empty means no n-gram table,
-        # so emit no PLE keys rather than optional ones
-        ple_layers = [] if self._no_ple else [i - 1 for i in hp["ple_layer_ids"]]
+        # so emit no PLE keys rather than optional ones. An MTP-only export has no
+        # PLE layer either, and its filter has already dropped the hash constants
+        # that would be read below.
+        ple_layers = [] if (self._no_ple or self.mtp_only) else [i - 1 for i in hp["ple_layer_ids"]]
         if not ple_layers:
             return
         self.gguf_writer.add_ple_layers(ple_layers)


### PR DESCRIPTION
`filter_tensors` drops every trunk tensor in `mtp_only` mode, the three int64 hash constants included, and `set_gguf_parameters` then failed with `PLE constant 'ple_embedding.layer_multipliers' missing from the checkpoint`. The draft block has no PLE layer and no table, so the keys are omitted the same way `--no-ple` omits them; the loader treats them as optional.

With this, the head exports from just the shards that hold `mtp.*` plus `embed_tokens` / `lm_head` (31 of 131, 58 GB) instead of the whole checkpoint. The result loads and drafts: 0.84–0.91 acceptance on code against UD-IQ4_XS and UD-Q4_K_XL targets — published as `dzannotti/Qwen3.8-Flash-Next-MTP-GGUF` (Q4_K_M with a Q4_K LM head, plus the BF16 export), with a note crediting this branch for the graph and the export.

