### PR TITLE
qwen4exp: reuse the graph between same-shape decodes

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1336,7 +1336,12 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
     const auto gparams = graph_params(res, ubatch, mctx, gtype);
 
+    // LLAMA_GRAPH_TIMING=1: log where the CPU time of a decode goes (build, alloc, inputs)
+    static const bool graph_timing = getenv("LLAMA_GRAPH_TIMING") && atoi(getenv("LLAMA_GRAPH_TIMING")) != 0;
+    int64_t t_build = 0, t_alloc = 0, t_inputs = 0;
+    bool reused = false;
     if (!graph_reuse_disable && res->can_reuse(gparams)) {
+        reused = true;
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
 
         // with pipeline parallelism, the previous graph_compute_async may still be running
@@ -1353,11 +1358,11 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         ggml_backend_sched_reset(sched.get());
         ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
 
-        //const auto t_start_us = ggml_time_us();
+        const auto t_build_us = ggml_time_us();
 
         gf = model.build_graph(gparams);
 
-        //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+        t_build = ggml_time_us() - t_build_us;
 
         if (!gf) {
             LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
@@ -1365,21 +1370,28 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             return nullptr;
         }
 
+        const auto t_alloc_us = ggml_time_us();
         if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
         }
+        t_alloc = ggml_time_us() - t_alloc_us;
     }
 
     // set the input data for the input tensors
     {
-        //const auto t_start_us = ggml_time_us();
+        const auto t_inputs_us = ggml_time_us();
 
         // FIXME this call causes a crash if any model inputs were not used in the graph and were therefore not allocated
         res->set_inputs(&ubatch);
 
-        //LLAMA_LOG_INFO("graph set inputs time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+        t_inputs = ggml_time_us() - t_inputs_us;
+        if (graph_timing) {
+            LLAMA_LOG_WARN("graph-timing: n_tokens=%3u gtype=%d reused=%d build=%.2f alloc=%.2f inputs=%.2f ms nodes=%d\n",
+                           ubatch.n_tokens, (int) gtype, (int) reused, t_build/1000.0, t_alloc/1000.0, t_inputs/1000.0,
+                           ggml_graph_n_nodes(res->get_gf()));
+        }
     }
 
     const auto status = graph_compute(res->get_gf(), ubatch.n_tokens > 1);

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -577,6 +577,33 @@ public:
         mctx->set_input_qsa(cell_blk, blk_cells, blk_pos, bias, ubatch, ratio);
     }
 
+    // Every tensor here is sized by n_tokens, n_kv and n_stream, so the graph can be
+    // reused whenever those three are unchanged; set_input refills the contents. Without
+    // this the whole qwen4exp graph was rebuilt and reallocated on every decode
+    // ("graphs reused = 0"), a fixed cost on each of the draft head's steps too.
+    bool can_reuse(const llm_graph_params & params) override {
+        const auto * hctx = static_cast<const llama_memory_hybrid_context *>(params.mctx);
+        const auto * mctx_new = hctx->get_idx();
+        if (mctx_new == nullptr) {
+            return false;
+        }
+        this->mctx = mctx_new;
+
+        const int64_t n_kv     = mctx_new->get_n_kv();
+        const int64_t n_stream = mctx_new->get_n_stream();
+        const int64_t n_tokens = params.ubatch.n_tokens;
+        const int64_t n_blocks = (n_kv + ratio - 1)/ratio;
+
+        bool res = true;
+        res &= k_idxs->ne[0]    == n_tokens;
+        res &= cell_blk->ne[0]  == n_kv && cell_blk->ne[1] == n_stream;
+        res &= blk_cells->ne[0] == (int64_t) ratio*n_blocks && blk_cells->ne[1] == n_stream;
+        res &= blk_pos->ne[0]   == 4*n_blocks*n_stream;
+        res &= n_stream > 0 && n_tokens % n_stream == 0;
+        res &= bias->ne[0] == n_kv && bias->ne[1] == n_tokens/n_stream && bias->ne[2] == n_stream;
+        return res;
+    }
+
     // Per-stream: a cell index means a different token in each stream. n_stream 1 = the old shapes.
     ggml_tensor * k_idxs    = nullptr;   // I32 [n_tokens]
     ggml_tensor * cell_blk  = nullptr;   // I32 [n_kv, n_stream]
@@ -997,6 +1024,12 @@ public:
     virtual ~llm_graph_input_ple() = default;
 
     void set_input(const llama_ubatch * ubatch) override;
+
+    // the index vector is [ple_n_heads * n_tokens] and set_input recomputes it on
+    // every ubatch, so only the token count has to match
+    bool can_reuse(const llm_graph_params & params) override {
+        return rows != nullptr && rows->ne[0] == (int64_t) pmodel.hparams.ple_n_heads * params.ubatch.n_tokens;
+    }
 
     ggml_tensor * rows = nullptr;   // I32 [ple_n_heads * n_tokens]
 


### PR DESCRIPTION
The QSA and PLE graph inputs had no `can_reuse()`, so every decode rebuilt and reallocated the ~8,000-node qwen4exp graph (`graphs reused = 0` in the server timings) — on the target and on each step of the MTP draft head. Both inputs are sized by `n_tokens`, `n_kv` and `n_stream` and refilled by `set_input`, so they can reuse under the same conditions as the attention inputs (the QSA one re-binds its indexer cache context the way `llm_graph_input_attn_kv` does).

Measured on Strix Halo / ROCm: single-token pass 49.6 → 46.7 ms (build 0.9 + alloc 1.4 ms per decode gone); on Vulkan the saving is the same CPU time.

Also adds `LLAMA_GRAPH_TIMING=1`, which logs build / alloc / set_inputs time and the node count per decode — it is what made this visible, and it is cheap to keep behind the env.
